### PR TITLE
Bugfix: unexpected token < cordova.js

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -42,7 +42,15 @@
 
 <body>
     <div id="root"></div>
-   <script type="text/javascript" src="cordova.js"></script>
+    <script>
+        const isCordovaApp = document.URL.indexOf('http://') === -1 && document.URL.indexOf('https://') === -1;
+        if (isCordovaApp) {
+          let script = document.createElement('script');
+          script.type = 'text/javascript';
+          script.src = 'cordova.js';
+          document.body.appendChild(script);
+        }
+    </script>
 </body>
 
 </html>

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ const startApp = () => {
   registerServiceWorker();
 }
 
-if(!window.cordova) {
+if (!window.cordova) {
   startApp();
 } else {
   document.addEventListener('deviceready', startApp, false);


### PR DESCRIPTION
This error occurs because there is a script tag to include `cordova.js` in `public/index.html`. The temporary solution is to only put this tag when in Cordova.