### PR TITLE
improving style of the app

### DIFF
--- a/cordova-app/config.xml
+++ b/cordova-app/config.xml
@@ -51,6 +51,7 @@
         <icon src="res/icon/ios/icon-small@2x.png" width="58" />
         <icon src="res/icon/ios/icon-small@3x.png" width="87" />
         <splash src="res/screen/ios/Default@2x~universal~anyany.png" />
+        <preference name="DisallowOverscroll" value="true" />
     </platform>
     <hook src="scripts/changeVersion.js" type="before_prepare" />
     <plugin name="cordova-plugin-whitelist" spec="^1.3.3" />

--- a/src/components/PageWrapper.js
+++ b/src/components/PageWrapper.js
@@ -12,6 +12,10 @@ const styles = theme => ({
     flexDirection:'column',
     flex: 1,
     height:'100%',
+    position:'fixed',
+    right:0,
+    left:0,
+    bottom:0
   },
   main:{
     marginBottom: theme.spacing.unit,

--- a/src/components/PageWrapper.js
+++ b/src/components/PageWrapper.js
@@ -23,6 +23,7 @@ const styles = theme => ({
     flexDirection:'column',
     flex: 1,
     overflowY: 'auto',
+    '-webkit-overflow-scrolling': 'touch'
   },
   logo: {
     height: '80px',

--- a/src/components/PhotoPage.js
+++ b/src/components/PhotoPage.js
@@ -35,6 +35,9 @@ const styles = theme => ({
       borderBottomColor: theme.palette.secondary.main,
     },
   },
+  progress: {
+    margin: theme.spacing.unit * 2
+  },
 });
 
 class PhotoPage extends Component {
@@ -229,7 +232,11 @@ class PhotoPage extends Component {
               <DialogContentText id="loading-dialog-text">
                 Be patient ;)
               </DialogContentText>
-              <CircularProgress color='secondary' size={50} thickness={6}/>
+              <CircularProgress
+              className={classes.progress}
+               color='secondary'
+               size={50}
+               thickness={6}/>
             </DialogContent>
           </Dialog>
 

--- a/src/components/PhotoPage.scss
+++ b/src/components/PhotoPage.scss
@@ -3,6 +3,10 @@
   flex: 1;
   flex-direction: column;
   height: 100%;
+  position:fixed;
+  right:0;
+  left:0;
+  bottom:0;
 
   .close-icon {
     display: flex;

--- a/src/components/WriteFeedbackPage.js
+++ b/src/components/WriteFeedbackPage.js
@@ -22,7 +22,11 @@ const styles = theme => ({
     display: 'flex',
     flex: 1,
     flexDirection: 'column',
-    height: '100%'
+    height: '100%',
+    position:'fixed',
+    right:0,
+    left:0,
+    bottom:0,
   },
   closeIcon: {
     display: 'flex',

--- a/src/components/WriteFeedbackPage.js
+++ b/src/components/WriteFeedbackPage.js
@@ -36,6 +36,7 @@ const styles = theme => ({
   content: {
     height: '100%',
     overflow:'auto',
+    '-webkit-overflow-scrolling': 'touch',
     marginTop: theme.spacing.unit * 0.5,
     marginBottom: theme.spacing.unit * 0.5,
     marginLeft: theme.spacing.unit * 1.5,

--- a/src/components/WriteFeedbackPage.js
+++ b/src/components/WriteFeedbackPage.js
@@ -44,7 +44,7 @@ const styles = theme => ({
   },
   button: {
     display: 'flex',
-    flexDirection: 'column',
+    alignItems: 'center',
     justifyContent: 'center',
     margin: theme.spacing.unit * 1.5
   },

--- a/src/components/WriteFeedbackPage.js
+++ b/src/components/WriteFeedbackPage.js
@@ -45,7 +45,7 @@ const styles = theme => ({
   button: {
     display: 'flex',
     flexDirection: 'column',
-    justifyContent: 'flex-end',
+    justifyContent: 'center',
     margin: theme.spacing.unit * 1.5
   },
   progress: {
@@ -172,8 +172,8 @@ class WriteFeedbackPage extends React.Component {
               type='string'
               required
               margin='dense'
-              rows={window.innerHeight > 667 ? 25 : window.innerHeight > 640 ? 21 : window.innerHeight > 480 ? 13 : 11}
-              rowsMax={window.innerHeight > 667 ? 26 : window.innerHeight > 640 ? 22 : window.innerHeight > 480 ? 14 : 12}
+              rows={window.innerHeight > 667 ? 23 : window.innerHeight > 640 ? 19 : window.innerHeight > 480 ? 11 : 9}
+              rowsMax={window.innerHeight > 667 ? 24 : window.innerHeight > 640 ? 20 : window.innerHeight > 480 ? 12 : 10}
               multiline
             />
           </div>


### PR DESCRIPTION
Changing position's page to fixed solves the issue of overscrolling for pwa ios(801ed71).
In the map style is not used the fixed position as in mapbox v0.52 during rotation the canvas becomes half white to ios devices and creates viewing bugs.

Specific configuration for avoiding the overscrolling for cordova(3729e24).

The number of rows in feedback page is reduced by two because it overflows eg in iphone 6.

ios scrolling better but not perfect support