### PR TITLE
thumbnails not appearing in iframe in Safari browser - solving #296

### DIFF
--- a/src/firebaseInit.js
+++ b/src/firebaseInit.js
@@ -20,6 +20,9 @@ firestore.enablePersistence()
     } else if (err.code === 'unimplemented') {
       console.error("The current browser does not support all of the features required to enable persistence  ...");
     }
+    else {
+      console.log("Error firestore.enablePersistence(); didn't work" );
+    }
   });
 
 export default firebaseApp;


### PR DESCRIPTION
It seems that the iframe doesn't allow firestore to enable persistence.
The extra else clause seems to solve the problem.