### PR TITLE
Fix picture zoom broken for web (embeddable)

### DIFF
--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -339,7 +339,9 @@ class Map extends Component {
           </Dialog>
           <Dialog open={this.state.openDialog} onClose={this.handleDialogClose}>
             <DialogContent>
-              <img onError={(e) => { e.target.src=placeholderImage}} className={"main-image"} alt={''} src={feature.properties.main}/>
+              <div style={{ textAlign: 'center' }}>
+                <img onError={(e) => { e.target.src=placeholderImage}} className={'main-image'} alt={''} src={feature.properties.main}/>
+              </div>
               <Card>
                 <CardActionArea>
                   <CardContent>

--- a/src/components/ModeratorPage.js
+++ b/src/components/ModeratorPage.js
@@ -132,7 +132,9 @@ class ModeratorPage extends Component {
 
         <Dialog open={this.state.zoomDialogOpen} onClose={this.handleZoomDialogClose}>
           <DialogContent>
-            <img onError={(e) => { e.target.src=placeholderImage}} className={'main-image'} alt={this.state.photoSelected.id} src={this.state.photoSelected.main}/>
+            <div style={{ textAlign: 'center' }}>
+              <img onError={(e) => { e.target.src=placeholderImage}} className={'main-image'} alt={this.state.photoSelected.id} src={this.state.photoSelected.main}/>
+            </div>
             <CardComponent
               photoSelected={this.state.photoSelected}
               handleRejectClick={this.handleRejectClick}

--- a/src/components/ModeratorPage.scss
+++ b/src/components/ModeratorPage.scss
@@ -1,4 +1,4 @@
 .main-image {
-  max-height: 50vh;
+  max-height: 60vh;
   max-width: 100%;
 }

--- a/src/components/ModeratorPage.scss
+++ b/src/components/ModeratorPage.scss
@@ -1,4 +1,4 @@
 .main-image {
-  height: 100%;
-  width: 100%;
+  max-height: 50vh;
+  max-width: 100%;
 }


### PR DESCRIPTION
Picture doesn't resize correctly in the dialog but hidden by the scroll bar.
Class `main-image` used both in moderator and the map for styling the image.
Set max height based on viewport-relative unit.

Fix #330 